### PR TITLE
Fix | macOS, iOS の表記を修正

### DIFF
--- a/lib/gh-utils.ts
+++ b/lib/gh-utils.ts
@@ -47,7 +47,7 @@ const getReadableName = (name: string): string => {
     return 'Windows Portable';
   }
   if (name.includes('dmg')) {
-    return 'MacOS';
+    return 'macOS';
   }
 
   return name;

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -24,17 +24,17 @@ export const getComponent = (node: React.ReactNode, returnIfProduction: boolean 
 export const platformOptions = {
   "windows": "Windows",
   "linux": "Linux",
-  "macos": "MacOS",
+  "macos": "macOS",
   "android": "Android",
-  "ios": "IOS",
+  "ios": "iOS",
 } as Record<string, string>;
 
 export enum Platform {
   Linux = 'Linux',
   Windows = 'Windows',
-  MacOS = 'MacOS',
+  MacOS = 'macOS',
   Android = 'Android',
-  IOS = 'IOS',
+  IOS = 'iOS',
 }
 
 export const convertOptionToPlatform = (option: string): Platform => {


### PR DESCRIPTION
Apple Style Guide を参考に表記を修正しました。(変える場所が正しいかはわかりません)
- `MacOS` > `macOS`
- `IOS` > `iOS`