### PR TITLE
Disable the default fallback font and specify the sans-serif family.

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -23,6 +23,8 @@ export async function generateMetadata(): Promise<Metadata> {
 
 const fontSans = FontSans({
   subsets: ["latin"],
+  fallback: ["sans-serif"],
+  adjustFontFallback: false
 })
 
 export default async function RootLayout({children}: RootLayoutProps) {


### PR DESCRIPTION
## Why
When using languages other than English, some browsers may display text in a serif font due to an inappropriate fallback font.

### Before
![image](https://github.com/user-attachments/assets/b468efea-c8f8-4898-b71c-2d80f70a17c8)

### After
![image](https://github.com/user-attachments/assets/cf0e1e0e-0234-4b35-a4b5-04fe98d205ad)
