### PR TITLE
Set the revalidate option in the fetch API to explicitly define the cache expiration time.

### DIFF
--- a/app/[lang]/page.tsx
+++ b/app/[lang]/page.tsx
@@ -37,7 +37,7 @@ const getHeroProps = async (lang: Locale) => {
 const getFirstTwoArticles = async (top: number = 2) => {
   const res = await fetch(
     'https://wpapi.ablaze.one/?home=https://blog.ablaze.one/&categories=45',
-    { next: { revalidate: 1800 } }
+    { next: { revalidate: 3600 } }
   );
   const articles = (await res.json()).items;
   let result: ArticleResponse[] = [];

--- a/app/[lang]/page.tsx
+++ b/app/[lang]/page.tsx
@@ -35,7 +35,10 @@ const getHeroProps = async (lang: Locale) => {
 }
 
 const getFirstTwoArticles = async (top: number = 2) => {
-  const res = await fetch('https://wpapi.ablaze.one/?home=https://blog.ablaze.one/&categories=45');
+  const res = await fetch(
+    'https://wpapi.ablaze.one/?home=https://blog.ablaze.one/&categories=45',
+    { next: { revalidate: 1800 } }
+  );
   const articles = (await res.json()).items;
   let result: ArticleResponse[] = [];
   for (let i = 0; i < Math.min(articles.length, top); i++) {


### PR DESCRIPTION
## Why
In Next.js 14, the default caching behavior of the fetch API is set to force-cache, which does not have an automatic cache-clearing mechanism. As a result, outdated data may occasionally be displayed in sections like "Latest articles".

fixed: #66